### PR TITLE
[QOL] TPD Nearest Hour

### DIFF
--- a/alerter/BinancePumpAndDumpAlerter.py
+++ b/alerter/BinancePumpAndDumpAlerter.py
@@ -16,6 +16,7 @@ class BinancePumpAndDumpAlerter:
         outlier_intervals,
         top_report_intervals,
         extract_interval,
+        retry_interval,
         reset_interval,
         top_pump_enabled,
         top_dump_enabled,
@@ -32,6 +33,7 @@ class BinancePumpAndDumpAlerter:
         self.pairs_of_interest = pairs_of_interest
         self.outlier_intervals = outlier_intervals
         self.extract_interval = extract_interval
+        self.retry_interval = retry_interval
         self.reset_interval = reset_interval
         self.top_pump_enabled = top_pump_enabled
         self.top_dump_enabled = top_dump_enabled

--- a/alerter/BinancePumpAndDumpAlerter.py
+++ b/alerter/BinancePumpAndDumpAlerter.py
@@ -24,7 +24,7 @@ class BinancePumpAndDumpAlerter:
         no_of_reported_coins,
         dump_enabled,
         check_new_listing_enabled,
-        tpd_round_hour_enabled,
+        top_report_nearest_hour,
         telegram,
         report_generator,
     ):
@@ -64,7 +64,7 @@ class BinancePumpAndDumpAlerter:
             self.top_report_intervals[interval] = {}
 
             # Determine initial start time for TPD. Should conveniently solve original 0% issue together.
-            if tpd_round_hour_enabled:
+            if top_report_nearest_hour:
                 self.top_report_intervals[interval]["start"] = tpd_nearest_hour
             else:
                 self.top_report_intervals[interval]["start"] = self.initial_time

--- a/config.yml
+++ b/config.yml
@@ -95,3 +95,5 @@ resetInterval: 6h
 priceRetryInterval: 5s
 # Disables checking and adding of new listing pairs
 checkNewListingEnabled: True
+# Disables rounding to nearest hour for first TPD if false
+tpdNearestHour: True

--- a/config.yml
+++ b/config.yml
@@ -96,4 +96,4 @@ priceRetryInterval: 5s
 # Disables checking and adding of new listing pairs
 checkNewListingEnabled: True
 # Disables rounding to nearest hour for first TPD if false
-tpdNearestHour: True
+topReportNearestHour: True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: "./Dockerfile"
-    image: binance-pump-alerts
+    image: patbaumgartner/binance-pump-alerts:latest
     # image: brianleect/binance-pump-alerts:latest
     restart: "no"
     environment:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,6 +72,9 @@ process_config() {
     if [[ -n $CHECK_NEW_LISTING_ENABLED ]]; then
         sed -i "s/checkNewListingEnabled.*/checkNewListingEnabled: ${CHECK_NEW_LISTING_ENABLED}/" config.yml
     fi
+    if [[ -n $TPD_NEAREST_HOUR ]]; then
+        sed -i "s/tpdNearestHour.*/tpdNearestHour: ${TPD_NEAREST_HOUR}/" config.yml
+    fi
 }
 
 # Adding parameters set from the environment variables to the config yaml file.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,8 +72,8 @@ process_config() {
     if [[ -n $CHECK_NEW_LISTING_ENABLED ]]; then
         sed -i "s/checkNewListingEnabled.*/checkNewListingEnabled: ${CHECK_NEW_LISTING_ENABLED}/" config.yml
     fi
-    if [[ -n $TPD_NEAREST_HOUR ]]; then
-        sed -i "s/tpdNearestHour.*/tpdNearestHour: ${TPD_NEAREST_HOUR}/" config.yml
+    if [[ -n $TOP_REPORT_NEAREST_HOUR ]]; then
+        sed -i "s/topReportNearestHour.*/topReportNearestHour: ${TOP_REPORT_NEAREST_HOUR}/" config.yml
     fi
 }
 

--- a/pumpAlerts.py
+++ b/pumpAlerts.py
@@ -79,7 +79,7 @@ def main():
         no_of_reported_coins=config["noOfReportedCoins"],
         dump_enabled=config["dumpEnabled"],
         check_new_listing_enabled=config["checkNewListingEnabled"],
-        tpd_round_hour_enabled=config["tpdNearestHour"],
+        tpd_round_hour_enabled=config["topReportNearestHour"],
         telegram=telegram,
         report_generator=reporter,
     )

--- a/pumpAlerts.py
+++ b/pumpAlerts.py
@@ -12,7 +12,7 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 config_file = "config.yml"
 
 # Using dev config while development
-config_dev_file = "config.dev.yml"
+config_dev_file = "config.yml"
 if os.path.isfile(config_dev_file):
     config_file = config_dev_file
 
@@ -69,9 +69,6 @@ def main():
         outlier_intervals=config["outlierIntervals"],
         top_report_intervals=config["topReportIntervals"],
         extract_interval=ConversionUtils.duration_to_seconds(config["extractInterval"]),
-        retry_interval=ConversionUtils.duration_to_seconds(
-            config["priceRetryInterval"]
-        ),
         reset_interval=ConversionUtils.duration_to_seconds(config["resetInterval"]),
         top_pump_enabled=config["topPumpEnabled"],
         top_dump_enabled=config["topDumpEnabled"],
@@ -79,6 +76,7 @@ def main():
         no_of_reported_coins=config["noOfReportedCoins"],
         dump_enabled=config["dumpEnabled"],
         check_new_listing_enabled=config["checkNewListingEnabled"],
+        tpd_round_hour_enabled=config["tpdNearestHour"],
         telegram=telegram,
         report_generator=reporter,
     )

--- a/pumpAlerts.py
+++ b/pumpAlerts.py
@@ -79,7 +79,7 @@ def main():
         no_of_reported_coins=config["noOfReportedCoins"],
         dump_enabled=config["dumpEnabled"],
         check_new_listing_enabled=config["checkNewListingEnabled"],
-        tpd_round_hour_enabled=config["topReportNearestHour"],
+        top_report_nearest_hour=config["topReportNearestHour"],
         telegram=telegram,
         report_generator=reporter,
     )

--- a/pumpAlerts.py
+++ b/pumpAlerts.py
@@ -12,7 +12,7 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 config_file = "config.yml"
 
 # Using dev config while development
-config_dev_file = "config.yml"
+config_dev_file = "config.dev.yml"
 if os.path.isfile(config_dev_file):
     config_file = config_dev_file
 

--- a/pumpAlerts.py
+++ b/pumpAlerts.py
@@ -69,6 +69,9 @@ def main():
         outlier_intervals=config["outlierIntervals"],
         top_report_intervals=config["topReportIntervals"],
         extract_interval=ConversionUtils.duration_to_seconds(config["extractInterval"]),
+        retry_interval=ConversionUtils.duration_to_seconds(
+            config["priceRetryInterval"]
+        ),
         reset_interval=ConversionUtils.duration_to_seconds(config["resetInterval"]),
         top_pump_enabled=config["topPumpEnabled"],
         top_dump_enabled=config["topDumpEnabled"],


### PR DESCRIPTION
Default initializes TPD start time to nearest hour. 

Should fix 0% issue at the same time as well since nearest hour would act as a buffer. 
(Although not the original intention, it's interesting how it happens to fix the issue)