### PR TITLE
[Bug] Delay fix, round down hour

### DIFF
--- a/alerter/BinancePumpAndDumpAlerter.py
+++ b/alerter/BinancePumpAndDumpAlerter.py
@@ -315,8 +315,8 @@ class BinancePumpAndDumpAlerter:
                 + top_report_intervals[interval]["value"]
                 + 1
             ):
-                # Update time for new trigger
-                top_report_intervals[interval]["start"] = current_time
+                # Update time for new trigger, rounded down to nearest hour. Avoid delay over time.
+                top_report_intervals[interval]["start"] = current_time - (current_time % 3600) + 3600
 
                 self.logger.debug(
                     "Sending out top pump dump report. Interval: %s.", interval

--- a/alerter/BinancePumpAndDumpAlerter.py
+++ b/alerter/BinancePumpAndDumpAlerter.py
@@ -315,8 +315,9 @@ class BinancePumpAndDumpAlerter:
                 + top_report_intervals[interval]["value"]
                 + 1
             ):
-                # Update time for new trigger, rounded down to nearest hour. Avoid delay over time.
-                top_report_intervals[interval]["start"] = current_time - (current_time % 3600) + 3600
+            
+                # Update time for new trigger, rounded down to nearest interval. Avoid delay over time.
+                top_report_intervals[interval]["start"] = current_time - (current_time % ConversionUtils.duration_to_seconds(interval)) + ConversionUtils.duration_to_seconds(interval)
 
                 self.logger.debug(
                     "Sending out top pump dump report. Interval: %s.", interval


### PR DESCRIPTION
Closes #66 

Original suggestion was to restart at fixed intervals but it would lead to missing gaps of data that would not be easily resolved without additional complexity.

After some thought, considering delay due to message sending over time will always result in a message being sent later, a simple fix would just to constantly round down to the nearest hour while setting time for last trigger.

Will run this version and see if it resolves the TDPA delays before sending.